### PR TITLE
blank would cause to wrong defined value

### DIFF
--- a/wifidog/install.php
+++ b/wifidog/install.php
@@ -344,7 +344,7 @@ function saveConfig($data) {
         // maybe more than one define stentences
         $may_be_more_than_one_define_sentences = explode(";", $line );
         
-        for($may_be_more_than_one_define_sentences as $line){
+        foreach($may_be_more_than_one_define_sentences as $line){
             // remove possible existed blanks
             $no_more_blanks_line = trim($line);
             $line = $no_more_blanks_line . ";";

--- a/wifidog/install.php
+++ b/wifidog/install.php
@@ -341,13 +341,14 @@ function saveConfig($data) {
 
     foreach ($contentArray as $line) {
         #print "L=$line<BR>\n";
-        // remove possible existed blanks
-        $no_more_blanks_line = trim($line);
         // maybe more than one define stentences
-        $may_be_more_than_one_define_sentences = explode(";", $no_more_blanks_line );
+        $may_be_more_than_one_define_sentences = explode(";", $line );
         
         for($may_be_more_than_one_define_sentences as $line){
-            $line = $line . ";";
+            // remove possible existed blanks
+            $no_more_blanks_line = trim($line);
+            $line = $no_more_blanks_line . ";";
+            
             if (preg_match("/^define\((.+)\);/", $line, $matchesArray)) {
             	list ($key, $value) = explode(',', $matchesArray[1]);
             	$pattern = array (

--- a/wifidog/install.php
+++ b/wifidog/install.php
@@ -341,15 +341,22 @@ function saveConfig($data) {
 
     foreach ($contentArray as $line) {
         #print "L=$line<BR>\n";
-        if (preg_match("/^define\((.+)\);/", $line, $matchesArray)) {
-            list ($key, $value) = explode(',', $matchesArray[1]);
-            $pattern = array (
-                "/^'/",
-                "/'$/"
-            );
-            $replacement = array (
-                '',
-                ''
+        // remove possible existed blanks
+        $no_more_blanks_line = trim($line);
+        // maybe more than one define stentences
+        $may_be_more_than_one_define_sentences = explode(";", $no_more_blanks_line );
+        
+        for($may_be_more_than_one_define_sentences as $line){
+            $line = $line . ";";
+            if (preg_match("/^define\((.+)\);/", $line, $matchesArray)) {
+            	list ($key, $value) = explode(',', $matchesArray[1]);
+            	$pattern = array (
+                    "/^'/",
+                    "/'$/"
+                );
+            	$replacement = array (
+                    '',
+                    ''
                 );
                 $key = preg_replace($pattern, $replacement, trim($key));
                 //$value = preg_replace($pattern, $replacement, trim($value));
@@ -372,10 +379,12 @@ function saveConfig($data) {
                 else { // The key does not exist (no new value to be saved)
                     fwrite($fd, $line); # Write the same line in config.php
                 }
+            }else {
+                fwrite($fd, $line); # Write the line (not a define line). Ex: Commented text
+            }
         }
-        else {
-            fwrite($fd, $line); # Write the line (not a define line). Ex: Commented text
-        }
+        
+       
     }
 }
 


### PR DESCRIPTION
If there are some blanks in the define sentence or more than one define sentence in one line in the config.php (for example define('CONF_DATABASE_PORT', '5432'))，the defined value would not be got in the install.php, because the preg_match function(about line 350 in install.php) would fail.